### PR TITLE
Add env-driven PAGE_SIZE and USE_X_FORWARDED_HOST settings

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -236,6 +236,15 @@ REST_FRAMEWORK['DEFAULT_THROTTLE_RATES'] = {
     'v2.broadcasts': env('API_THROTTLE_V2_BROADCASTS', '2500/hour'),
 }
 
+# DRF page size — overridable via PAGE_SIZE env var. Default matches
+# upstream rapidpro/rapidpro (250) so unset deployments keep prior behaviour.
+REST_FRAMEWORK['PAGE_SIZE'] = int(env('PAGE_SIZE', 250))
+
+# Trust the X-Forwarded-Host header from the ingress when constructing
+# request.get_host(). Only enable when every ingress in front of the app
+# is trusted to strip/rewrite this header from clients.
+USE_X_FORWARDED_HOST = env('USE_X_FORWARDED_HOST', 'off') == 'on'
+
 MAILROOM_URL = env('MAILROOM_URL', '')
 MAILROOM_AUTH_TOKEN = env('MAILROOM_AUTH_TOKEN', '')
 


### PR DESCRIPTION
## Summary

- Make DRF's `REST_FRAMEWORK['PAGE_SIZE']` (default 250) overridable via the `PAGE_SIZE` env var.
- Make Django's `USE_X_FORWARDED_HOST` (default off) overridable via the `USE_X_FORWARDED_HOST` env var (accepts `"on"`/`"off"`, matching the surrounding `ENABLE_OIDC`/`SEND_*`/`DJANGO_DEBUG` idiom).